### PR TITLE
Add "format" field

### DIFF
--- a/src/enclave/util.h
+++ b/src/enclave/util.h
@@ -70,4 +70,18 @@ namespace afetch {
   {
     return sha256((uint8_t*)s.data(), s.size());
   }
+
+  std::vector<uint8_t> sha256_two(const std::vector<uint8_t>& a, const std::vector<uint8_t>& b)
+  {
+    std::vector<uint8_t> hash;
+    hash.resize(32);
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts_ret(&ctx, 0);
+    mbedtls_sha256_update_ret(&ctx, a.data(), a.size());
+    mbedtls_sha256_update_ret(&ctx, b.data(), b.size());
+    mbedtls_sha256_finish_ret(&ctx, hash.data());
+    mbedtls_sha256_free(&ctx);
+    return hash;
+  }
 }

--- a/src/enclave/util.h
+++ b/src/enclave/util.h
@@ -73,8 +73,7 @@ namespace afetch {
 
   std::vector<uint8_t> sha256_two(const std::vector<uint8_t>& a, const std::vector<uint8_t>& b)
   {
-    std::vector<uint8_t> hash;
-    hash.resize(32);
+    std::vector<uint8_t> hash(32);
     mbedtls_sha256_context ctx;
     mbedtls_sha256_init(&ctx);
     mbedtls_sha256_starts_ret(&ctx, 0);


### PR DESCRIPTION
This adds a `"format"` field to support different evidence formats in the future, both in terms of attestation formats (`"evidence"` and `"endorsements"` for the current OE-based format) and payload formats (the content inside `"data"`). The format is part of the SGX report data claim to prevent confusion attacks.