### PR TITLE
Switch to oesign to set enclave parameters

### DIFF
--- a/src/enclave/CMakeLists.txt
+++ b/src/enclave/CMakeLists.txt
@@ -32,4 +32,29 @@ target_link_libraries(afetch.enclave
     openenclave::oeenclave
     openenclave::oelibc)
 
-install(TARGETS afetch.enclave LIBRARY DESTINATION .)
+# Generate an ephemeral signing key
+set(signing_key ${CMAKE_CURRENT_BINARY_DIR}/signing_key.pem)
+add_custom_command(
+    OUTPUT ${signing_key}
+    COMMAND openssl genrsa -out ${signing_key} -3 3072
+)
+
+# Sign the enclave
+set(signed_enclave ${CMAKE_CURRENT_BINARY_DIR}/libafetch.enclave.so.signed)
+set(oe_conf ${CMAKE_CURRENT_LIST_DIR}/oe_sign.conf)
+add_custom_command(
+    OUTPUT ${signed_enclave}
+    COMMAND
+    openenclave::oesign sign -e ${CMAKE_CURRENT_BINARY_DIR}/libafetch.enclave.so -c
+    ${oe_conf} -k ${signing_key}
+    DEPENDS afetch.enclave ${oe_conf} ${signing_key}
+)
+
+add_custom_target(
+    afetch.enclave_signed ALL
+    DEPENDS ${signed_enclave}
+)
+
+install(FILES ${signed_enclave}
+    DESTINATION .
+)

--- a/src/enclave/enclave.cpp
+++ b/src/enclave/enclave.cpp
@@ -16,15 +16,6 @@
 #include "util.h"
 #include "afetch_t.h"
 
-// Default parameters, can be overridden during signing.
-OE_SET_ENCLAVE_SGX(
-    1,           /* ProductID */
-    1,           /* SecurityVersion */
-    true,        /* AllowDebug */
-    60960,       /* HeapPageCount */
-    13107,       /* StackPageCount */
-    2);          /* TCSCount */
-
 extern "C" void enclave_main(const char* url, const char* nonce, char** output) {
     oe_load_module_host_socket_interface();
     oe_load_module_host_resolver();

--- a/src/enclave/oe_sign.conf
+++ b/src/enclave/oe_sign.conf
@@ -1,0 +1,7 @@
+# Enclave settings:
+NumHeapPages=8192
+NumStackPages=1024
+NumTCS=2
+ProductID=1
+SecurityVersion=1
+Debug=0

--- a/src/host/host.cpp
+++ b/src/host/host.cpp
@@ -14,7 +14,7 @@ int main(int argc, const char* argv[])
     int ret = 1;
     oe_enclave_t* enclave = NULL;
 
-    uint32_t flags = OE_ENCLAVE_FLAG_DEBUG;
+    uint32_t flags = OE_ENCLAVE_FLAG_DEBUG_AUTO;
 
     if (argc != 5)
     {

--- a/tests/test.py
+++ b/tests/test.py
@@ -19,7 +19,7 @@ def test():
     # Run afetch
     subprocess.run([
         DIST_DIR / "afetch",
-        DIST_DIR / "libafetch.enclave.so",
+        DIST_DIR / "libafetch.enclave.so.signed",
         out_path,
         TEST_URL, TEST_NONCE
         ], check=True)


### PR DESCRIPTION
Also, by default the debug bit is unset now.