### PR TITLE
Return error responses

### DIFF
--- a/src/enclave/curl.h
+++ b/src/enclave/curl.h
@@ -46,9 +46,10 @@ namespace afetch {
   {
   public:
     struct Response {
+      int64_t status;
       std::vector<uint8_t> body;
       std::vector<std::string> cert_chain;
-      int64_t status;
+      std::string error_message;
     };
 
     static void global_init() {
@@ -91,13 +92,11 @@ namespace afetch {
 
       auto res = curl_easy_perform(curl);
       if (res != CURLE_OK) {
+        response.error_message = curl_easy_strerror(res);
         if (verbose) {
-          const char* err_s = curl_easy_strerror(res);
-          std::cerr << "Fetch failed: " << err_s << std::endl;
+          std::cerr << "Fetch failed: " << response.error_message << std::endl;
         }
-        response.status = 0;
-        response.body = std::vector<uint8_t>{};
-        response.cert_chain = std::vector<std::string>{};
+        response.status = NULL;
         return response;
       }
 

--- a/src/enclave/enclave.cpp
+++ b/src/enclave/enclave.cpp
@@ -32,7 +32,7 @@ extern "C" void enclave_main(const char* url, const char* nonce, char** output) 
         j["nonce"] = nonce;
 
         // Fetch URL
-        try{
+        try {
             auto response = curl.fetch(url);
             j["result"]["status"] = response.status;
             j["result"]["body"] = afetch::base64(response.body);

--- a/src/enclave/enclave.cpp
+++ b/src/enclave/enclave.cpp
@@ -22,23 +22,24 @@ extern "C" void enclave_main(const char* url, const char* nonce, char** output) 
     afetch::Curl::global_init();
 
     std::string format = "ATTESTED_FETCH_OE_SGX_ECDSA_V2";
-    
+
     try {
         afetch::Curl curl;
 
-        // Fetch URL
-        auto response = curl.fetch(url);
-
-        // Create output JSON
+        // Initialise output JSON
         nlohmann::json j;
         j["url"] = url;
         j["nonce"] = nonce;
-        if (response.status == NULL) {
-            j["error"]["message"] = response.error_message;
-        } else {
+
+        // Fetch URL
+        try{
+            auto response = curl.fetch(url);
             j["result"]["status"] = response.status;
             j["result"]["body"] = afetch::base64(response.body);
             j["result"]["certs"] = response.cert_chain;
+        }
+        catch (afetch::CurlError& e ) {
+            j["error"]["message"] = e.what();
         }
 
         std::string data_json = j.dump(1);

--- a/src/enclave/enclave.cpp
+++ b/src/enclave/enclave.cpp
@@ -33,6 +33,7 @@ extern "C" void enclave_main(const char* url, const char* nonce, char** output) 
         nlohmann::json j;
         j["url"] = url;
         j["nonce"] = nonce;
+        j["status"] = response.status;
         j["body"] = afetch::base64(response.body);
         j["certs"] = response.cert_chain;
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,7 +26,7 @@ def test(url, expected_status):
         out_path,
         url, TEST_NONCE
         ], check=True)
-    
+
     # Read attested result
     with open(out_path) as f:
         out = json.load(f)
@@ -34,7 +34,7 @@ def test(url, expected_status):
     # Check if the format is known
     if out["format"] != "ATTESTED_FETCH_OE_SGX_ECDSA_V2":
         raise RuntimeError(f"Unsupported format: {out['format']}")
-    
+
     # Verify evidence and endorsements using Open Enclave
     with tempfile.TemporaryDirectory() as tmpdir:
         # Run oeverify
@@ -47,7 +47,7 @@ def test(url, expected_status):
         result = subprocess.run([
             OEVERIFY, "-r", evidence_path, "-e", endorsements_path
             ], capture_output=True, universal_newlines=True, check=True)
-        
+
         # Extract report data from stdout
         prefix = "sgx_report_data:"
         sgx_report_data = None
@@ -69,13 +69,13 @@ def test(url, expected_status):
     assert data["nonce"] == TEST_NONCE, data["nonce"]
     assert data["url"] == url, data["url"]
     if expected_status is None:
-        assert data.get("result") == None, data.get("result")
-        assert data["error"]["message"] == "Couldn't connect to server", data["error"]["message"]
+        assert "result" not in data, data["result"]
+        assert data["error"]["message"] == "Curl error: Couldn't connect to server (https://localhost:1)", data["error"]["message"]
     else:
         assert data["result"]["status"] == expected_status, data["result"]["status"]
         assert len(data["result"]["certs"]) > 0, data["result"]["certs"]
         assert len(data["result"]["body"]) > 0, data["result"]["body"]
-        assert data.get("error") == None, data.get("error")
+        assert "error" not in data, data["error"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses: https://github.com/microsoft/attested-fetch/issues/6 

Attested fetch now returns responses regardless of their status codes.

To discuss: when attested fetch fails to get a http response, it now returns a custom empty response with status code 0.   